### PR TITLE
Fix a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ os.environ['ION_OS_MODE'] = '<number>'
 * Enable debug mode:
 ```python
 # Print full error stacktrace, the original pressed key and methods calls
-os.eviron['ION_ENABLE_DEBUG'] = ''
+os.environ['ION_ENABLE_DEBUG'] = ''
 ```
 
 * Disable reading inputs only in kandinsky window (if kandinsky is not imported globally, this option is enabled by default):


### PR DESCRIPTION
https://github.com/ZetaMap/Ion-numworks/blob/ecb9bb43e4e6b404c918a1f746f135317d84f401/README.md?plain=1#L132