### PR TITLE
Fix being unable to press a letter while `shift` is held

### DIFF
--- a/src/ion/util/stuff/keylogger.py
+++ b/src/ion/util/stuff/keylogger.py
@@ -26,7 +26,7 @@ class KeyLogger:
       if key is None: return # because the key can be None in some cases
 
       print_debug("Pressed", key)
-      if hasattr(key, "char"): key = key.char.lower()
+      if hasattr(key, "char"): key = key.char.lower() # We `.lower()` it, so that holding shift or having caplock enabled does not disable letter-binded keys.
       try: KeyLogger._focused = KeyLogger._check_focus()
       except BaseException as e:
         # an error occurs while checking focus, so pass this error to the main thread
@@ -44,7 +44,7 @@ class KeyLogger:
       if key is None: return # because the key can be None is some cases
 
       print_debug("Released", key)
-      if hasattr(key, "char"): key = key.char.lower()
+      if hasattr(key, "char"): key = key.char.lower() # We `.lower()` it, so that holding shift or having caplock enabled does not disable letter-binded keys.
 
       for i in range(NUMBER_OF_KEYS):
         k = ALL_KEYS[i]["key"]

--- a/src/ion/util/stuff/keylogger.py
+++ b/src/ion/util/stuff/keylogger.py
@@ -26,7 +26,7 @@ class KeyLogger:
       if key is None: return # because the key can be None in some cases
 
       print_debug("Pressed", key)
-      if hasattr(key, "char"): key = key.char
+      if hasattr(key, "char"): key = key.char.lower()
       try: KeyLogger._focused = KeyLogger._check_focus()
       except BaseException as e:
         # an error occurs while checking focus, so pass this error to the main thread
@@ -44,7 +44,7 @@ class KeyLogger:
       if key is None: return # because the key can be None is some cases
 
       print_debug("Released", key)
-      if hasattr(key, "char"): key = key.char
+      if hasattr(key, "char"): key = key.char.lower()
 
       for i in range(NUMBER_OF_KEYS):
         k = ALL_KEYS[i]["key"]


### PR DESCRIPTION
A small fix that just `.lower()` the detected pressed characters, so that pressing an uppercase letter is equivalent to pressing its lowercase counterpart.